### PR TITLE
chore: remove Next.js redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,15 +8,6 @@ const config = {
     domains: JSON.parse(process.env.STATIC_CONTENT_DOMAIN || "[]"),
   },
   productionBrowserSourceMaps: process.env.PRODUCTION_SOURCE_MAPS === "true",
-  redirects: async () => {
-    return [
-      {
-        source: '/prototipo',
-        destination: 'https://www.figma.com/proto/neNIFk5WvrKhnBHxqsryWo/Android-Application-Mock-ups',
-        permanent: false,
-      },
-    ];
-  },
   webpack: (config) => {
     config.module.rules.push({
       test: /\.svg$/,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

Remove Next.js redirect object from the config. Redirections in the config only work when using the built-in server, but not while using `next export` as Cloudflare Pages uses.

### Why is it needed

This code is unused.
