### PR TITLE
feat: add inverted Feature component

### DIFF
--- a/src/components/feature.tsx
+++ b/src/components/feature.tsx
@@ -3,21 +3,22 @@ import clsx from 'clsx';
 export type Props = {
   text: string,
   imageUrl: string,
+  inverted?: boolean,
   divClassName?: string,
   textClassName?: string,
 };
 
 const Feature = (props: Props): React.ReactElement | null => {
-  const { text, imageUrl, divClassName, textClassName } = props;
+  const { text, imageUrl, inverted, divClassName, textClassName } = props;
 
   return (
-    <div className={clsx(divClassName, "lg:min-h-screen lg:max-h-screen flex flex-col lg:flex-row pt-8 lg:px-16 lg:py-0")}>
+    <div className={clsx(divClassName, "lg:min-h-screen lg:max-h-screen flex flex-col pt-8 lg:px-16 lg:py-0", inverted ? "lg:flex-row-reverse" : "lg:flex-row")}>
       <div className="px-8 lg:px-0 flex flex-col justify-center items-center">
-        <span className={clsx(textClassName, "font-semibold text-center")}> 
+        <span className={clsx(textClassName, "font-semibold text-center")}>
           {text}
         </span>
       </div>
-      <div className="mt-8 lg:mt-0 py-10 px-8 lg:py-0 lg:px-0 lg:bg-transparent w-auto flex items-center justify-center lg:justify-end">
+      <div className={clsx("mt-8 lg:mt-0 py-10 px-8 lg:py-0 lg:px-0 lg:bg-transparent w-auto flex items-center justify-center", inverted ? "lg:justify-start" : "lg:justify-end")}>
         <img src={imageUrl} className="h-5/6 w-auto sm:w-2/5 sm:h-auto lg:h-5/6 lg:w-auto rounded-md" />
       </div>
     </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,6 +40,7 @@ const Home = (): React.ReactElement | null => {
         textClassName="text-background text-4xl"
       />
       <Feature
+        inverted
         text="Organiza y añade tus horarios para mayor variedad"
         imageUrl="/timetable@2x.png"
         divClassName="bg-background"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

This PR adds an `inverted` prop to the Feature component so that we can create a different type of layout.

### Usage

Just include the `inverted` prop to the Feature component:

```tsx
<Feature inverted />
```

### Why is it needed

This is part of the new layout.

